### PR TITLE
DEV-4438: Remove duplicates in files to be parsed

### DIFF
--- a/src/async_impl/proto_decoder.rs
+++ b/src/async_impl/proto_decoder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use bytes::Bytes;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -141,8 +142,8 @@ impl<'a> ProtoDecoder<'a> {
                         Err(e) => Err(e.into_cache()),
                     }
                 }
-                .boxed()
-                .shared();
+                    .boxed()
+                    .shared();
                 e.insert(v).value().clone()
             }
         }
@@ -170,7 +171,7 @@ fn add_files<'a>(
         files.push(registered_schema.schema);
         Ok(())
     }
-    .boxed()
+        .boxed()
 }
 
 #[derive(Debug)]
@@ -181,11 +182,12 @@ pub struct DecodeContext {
 
 fn into_decode_context(vec_of_schemas: Vec<String>) -> Result<DecodeContext, SRCError> {
     let resolver = MessageResolver::new(vec_of_schemas.last().unwrap());
-    let mut files: Vec<String> = Vec::new();
+    let mut files: HashSet<String> = HashSet::new();
     add_common_files(resolver.imports(), &mut files);
     for s in vec_of_schemas {
-        files.push(s);
+        files.insert(s);
     }
+
     match Context::parse(files) {
         Ok(context) => Ok(DecodeContext { resolver, context }),
         Err(e) => Err(SRCError::non_retryable_with_cause(

--- a/src/blocking/proto_decoder.rs
+++ b/src/blocking/proto_decoder.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use bytes::Bytes;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -135,13 +136,13 @@ pub struct DecodeResultWithContext {
 fn add_files(
     sr_settings: &SrSettings,
     registered_schema: RegisteredSchema,
-    files: &mut Vec<String>,
+    files: &mut HashSet<String>,
 ) -> Result<(), SRCError> {
     for r in registered_schema.references {
         let child_schema = get_referenced_schema(sr_settings, &r)?;
         add_files(sr_settings, child_schema, files)?;
     }
-    files.push(registered_schema.schema);
+    files.insert(registered_schema.schema);
     Ok(())
 }
 
@@ -157,7 +158,7 @@ fn to_resolve_context(
     registered_schema: RegisteredSchema,
 ) -> Result<Arc<DecodeContext>, SRCError> {
     let resolver = MessageResolver::new(&registered_schema.schema);
-    let mut files = Vec::new();
+    let mut files = HashSet::new();
     add_common_files(resolver.imports(), &mut files);
     add_files(sr_settings, registered_schema.clone(), &mut files)?;
     match Context::parse(&files) {

--- a/src/proto_common_types.rs
+++ b/src/proto_common_types.rs
@@ -1,13 +1,15 @@
+use std::collections::HashSet;
+
 /// Adds the schema of the common type imports
-pub(crate) fn add_common_files(imports: &Vec<String>, files: &mut Vec<String>) {
+pub(crate) fn add_common_files(imports: &Vec<String>, files: &mut HashSet<String>) {
     for import in imports {
         if let Some(common_schema) = is_common_import(import) {
-            files.push(String::from(get_schema(&common_schema)));
+            files.insert(String::from(get_schema(&common_schema)));
             continue;
         }
         if let Some(common_type) = is_common_type_import(import) {
             for common_schema in get_schemas(common_type) {
-                files.push(String::from(get_schema(common_schema)))
+                files.insert(String::from(get_schema(common_schema)));
             }
         }
     }


### PR DESCRIPTION
We have identified that if A.proto has 2 imports B and C, both B and C internally import D, it is causing duplicate import error. This PR puts the proto files in hashset thereby handling this case